### PR TITLE
Add Lee County source metadata registry

### DIFF
--- a/lee/sources/SOURCES.md
+++ b/lee/sources/SOURCES.md
@@ -1,0 +1,63 @@
+# Lee County, FL — data source registry
+
+`sources.json` is the machine-readable registry of the public data sources behind Lee
+County's elephant-xyz ingestion: what each source is, how it is accessed, how it
+refreshes, how completeness is checked, and the traps that have already bitten us.
+`sources.schema.json` validates it. `last_verified` records the date of the most recent
+live URL verification (set it to `null` if a change is made without re-verifying).
+
+Last verification (2026-06-12, US egress): leepa.org, Accela LEECO, and dos.fl.gov/sunbiz
+all answer 200; bbb.org answers 403 to plain curl — that is the documented bot challenge,
+not an outage (the harvester retries through it).
+
+## The four sources
+
+**Lee County Property Appraiser** (`leepa.org`) — the appraisal backbone, ~516k parcels
+scraped via browser flows (`LeeCurated.json` + `LeeCostCard.json`; referenced by skills,
+not yet published in oracle-node main). Search is by STRAP, and the exact punctuation
+matters — it must match the portal's format. No CAPTCHA, but the portal only tolerates
+~3-4 concurrent sessions. Refresh is a repair-mode re-prepare from the seed CSV
+(`s3://counties-seeds/lee.csv`), quarterly or on demand, gated by MVL mirror-validation
+(global completeness >= 0.8 per prepared/transformed pair) plus seed-vs-prepared count
+reconciliation.
+
+**Accela permits** (`aca-prod.accela.com/LEECO/`) — browser-required detail pages,
+harvested property-first for permit-eligible (commercial/industrial) parcels from the
+seed. The big one: a detail page can display a *different parcel* than the one you
+searched. Early Lee loads linked permits to the displayed parcel and were corrupted,
+forcing a repair — permits must always be linked via `propertyFirstTarget` (the
+requested parcel). The permit portal's parcel-id format also differs from the
+appraiser's STRAP, so normalization is required. Start concurrency at 2; the portal
+degrades above ~4.
+
+**Florida Sunbiz** (`dos.fl.gov/sunbiz/`) — statewide corporate registrations, scoped to
+Lee by ZIP-prefix matching (~12.6M records scanned, ~379k Lee-matched). Quarterly bulk
+`cordata.zip` (~1.7 GB) plus daily `YYYYMMDDc.txt` incrementals. Two traps: the download
+host is Cloudflare-challenged (plain curl fails; use a real browser — the exact bulk URL
+is undocumented in the skills), and `cordata.zip` is ZIP method 9 (Deflate64), which
+streaming libs cannot read in Lambda — expand locally and stage the `.txt` entries to S3
+(`--source-format text`). Known gaps, deliberately left open: `corevent.zip` filing
+history is not ingested, and `party_type_code` decoding is incomplete.
+
+**BBB** (`bbb.org/us/category/<category>`) — contractor reputation, joined to permits by
+contractor name. Puppeteer category crawl via `harvest-bbb-category.mjs` (referenced by
+skills, not yet published), resumable and tunable (`--page-delay-ms 2000`,
+`--profile-delay-ms 1500`, `--start-page`/`--max-pages`/`--max-profiles`). BBB serves
+bot challenges; the script retries through them (`--challenge-attempts`,
+`--challenge-check-interval-ms`), but datacenter IPs may need `--headless false`.
+
+## Cross-cutting operational notes
+
+- **US egress gate** — all *local* probing of these sources requires a US egress IP;
+  check `curl -s ipinfo.io/country` before debugging any block. Lambda workers run from
+  US AWS regions and are unaffected.
+- **Budget-handler incident** — a budget alarm once silently disabled the event-source
+  mappings mid-run, stalling ingestion with no errors. If ingest stalls, first confirm
+  `EmergencyStopEnabled=false` and that the mappings are `Enabled`.
+
+## How to update this registry
+
+Open a PR against this repo. Keep `sources.json` valid against `sources.schema.json`
+(`npx --yes ajv-cli validate -s sources.schema.json -d sources.json`). This is the first
+instance of a per-county source-registry pattern — new counties should copy this layout
+under `<county>/sources/`.

--- a/lee/sources/sources.json
+++ b/lee/sources/sources.json
@@ -1,0 +1,119 @@
+{
+  "county": "lee",
+  "state": "FL",
+  "registry_version": 1,
+  "last_verified": "2026-06-12",
+  "sources": [
+    {
+      "id": "lee-appraisal",
+      "category": "property_appraisal",
+      "provider": "Lee County Property Appraiser",
+      "urls": {
+        "portal": "https://www.leepa.org/"
+      },
+      "access_pattern": "browser-flow",
+      "access_details": {
+        "search_key": "STRAP (exact punctuation critical — must match the portal's format)",
+        "browser_flows": ["LeeCurated.json", "LeeCostCard.json"],
+        "browser_flows_status": "referenced by skills; not yet published in oracle-node main"
+      },
+      "batch_available": false,
+      "refresh_method": "repair-mode re-prepare from seed CSV",
+      "refresh_cadence": "quarterly / on-demand",
+      "seed": "s3://counties-seeds/lee.csv",
+      "scale": {
+        "approx_parcels": 516000
+      },
+      "completeness_check": "MVL (mirror-validation) global completeness >= 0.8 per prepared/transformed pair, enforced by oracle-node workflow/lambdas/mvl; plus seed-count vs prepared-count reconciliation",
+      "anti_bot": {
+        "captcha": false,
+        "us_egress_required_for_local_probing": true,
+        "concurrency": "portal tolerates ~3-4 concurrent",
+        "notes": "Lambda from US regions unaffected"
+      },
+      "downstream": ["properties", "addresses", "structures", "sales_histories"]
+    },
+    {
+      "id": "lee-permits",
+      "category": "permits",
+      "provider": "Accela Citizen Access (agency LEECO)",
+      "urls": {
+        "portal": "https://aca-prod.accela.com/LEECO/"
+      },
+      "access_pattern": "scrape",
+      "access_details": {
+        "browser_required": "detail pages require a real browser",
+        "adapter": "lee-accela.mjs (oracle-node permit-harvest worker; referenced by skills, not yet published)",
+        "message_types": ["lee-property-first-permit-parcel", "lee-property-first-seed-feeder"]
+      },
+      "batch_available": false,
+      "refresh_method": "property-first harvest from the seed for permit-eligible parcels (commercial/industrial usage types; env PROPERTY_FIRST_PERMIT_ELIGIBLE_USAGE_TYPES)",
+      "seed": "s3://counties-seeds/lee.csv",
+      "anti_bot": {
+        "captcha": false,
+        "us_egress_required_for_local_probing": true,
+        "concurrency": "start at 2; degrades above ~4"
+      },
+      "gotchas": [
+        "Detail page may display a different parcel than the one searched — permits must be linked via propertyFirstTarget (the requested parcel), never the displayed parcel",
+        "Parcel-id format differs from the appraiser's STRAP; normalization required"
+      ],
+      "downstream": ["permits", "property_improvements"]
+    },
+    {
+      "id": "fl-sunbiz",
+      "category": "business_registry",
+      "provider": "Florida DOS — Sunbiz Data Access",
+      "urls": {
+        "portal": "https://dos.fl.gov/sunbiz/",
+        "bulk": "Data Access portal; exact bulk URL undocumented in skills — Cloudflare-challenged, browser required"
+      },
+      "access_pattern": "bulk-download",
+      "batch_available": true,
+      "refresh_method": "quarterly corporate bulk cordata.zip (~1.7 GB) plus daily incrementals (YYYYMMDDc.txt); county scoping by ZIP-prefix matching (--lee-county-zips convenience flag; ZIP list lives in the not-yet-published enqueue script)",
+      "refresh_cadence": "quarterly bulk + daily incrementals",
+      "scale": {
+        "approx_statewide_records_scanned": 12600000,
+        "approx_lee_matched_records": 379000
+      },
+      "completeness_check": "invalidRecordCount == 0 && transformedRecordCount == sourceRecordCount, from the transform summary",
+      "anti_bot": {
+        "cloudflare_challenge": true,
+        "browser_required_for_download": true
+      },
+      "gotchas": [
+        "cordata.zip is ZIP method 9 (Deflate64) — streaming libs fail in Lambda; expand locally and stage the .txt entries to S3, then run with --source-format text"
+      ],
+      "known_gaps": [
+        "corevent.zip (filing history) not ingested",
+        "party_type_code decoding incomplete"
+      ],
+      "downstream": ["business_registrations", "business_registration_address", "business_registration_party"]
+    },
+    {
+      "id": "bbb",
+      "category": "business_reputation",
+      "provider": "Better Business Bureau (BBB.org)",
+      "urls": {
+        "category_pattern": "https://www.bbb.org/us/category/<category>"
+      },
+      "access_pattern": "scrape",
+      "access_details": {
+        "harvester": "Puppeteer via harvest-bbb-category.mjs (referenced by skills, not yet published)",
+        "delay_tuning": ["--page-delay-ms 2000", "--profile-delay-ms 1500"],
+        "challenge_handling": ["--challenge-attempts", "--challenge-check-interval-ms"],
+        "resume_flags": ["--start-page", "--max-pages", "--max-profiles"]
+      },
+      "batch_available": false,
+      "refresh_method": "category crawl, resumable",
+      "refresh_cadence": "on demand",
+      "anti_bot": {
+        "bot_challenges": true,
+        "us_egress_required_for_local_probing": true,
+        "headless": "default; use --headless false for datacenter-IP challenges"
+      },
+      "matching": "joined to permits by contractor name",
+      "downstream": ["bbb_* tables"]
+    }
+  ]
+}

--- a/lee/sources/sources.schema.json
+++ b/lee/sources/sources.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Per-county source-metadata registry",
+  "description": "Validates a county's sources.json for the elephant-xyz ingestion pipeline.",
+  "type": "object",
+  "required": ["county", "state", "sources"],
+  "additionalProperties": true,
+  "properties": {
+    "county": { "type": "string" },
+    "state": { "type": "string" },
+    "registry_version": { "type": "integer" },
+    "last_verified": {
+      "description": "Stamped by the caller after live URL verification; null until then.",
+      "type": ["string", "null"]
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/source" }
+    }
+  },
+  "definitions": {
+    "source": {
+      "type": "object",
+      "required": ["id", "category", "provider", "urls", "access_pattern", "refresh_method"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string" },
+        "category": {
+          "type": "string",
+          "enum": ["property_appraisal", "permits", "business_registry", "business_reputation"]
+        },
+        "provider": { "type": "string" },
+        "urls": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "access_pattern": {
+          "type": "string",
+          "enum": ["browser-flow", "http-api", "bulk-download", "scrape"]
+        },
+        "access_details": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "batch_available": { "type": "boolean" },
+        "refresh_method": { "type": "string" },
+        "refresh_cadence": { "type": "string" },
+        "seed": { "type": "string" },
+        "scale": {
+          "type": "object",
+          "additionalProperties": { "type": "number" }
+        },
+        "completeness_check": { "type": "string" },
+        "anti_bot": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "captcha": { "type": "boolean" },
+            "cloudflare_challenge": { "type": "boolean" },
+            "bot_challenges": { "type": "boolean" },
+            "us_egress_required_for_local_probing": { "type": "boolean" },
+            "concurrency": { "type": "string" },
+            "notes": { "type": "string" }
+          }
+        },
+        "gotchas": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "known_gaps": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "downstream": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "matching": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

First per-county source-metadata registry: `lee/sources/`

- `sources.json` — machine-readable registry of Lee's four public sources (appraisal / permits / Sunbiz / BBB): URLs, access patterns, refresh methods, concurrency caps, completeness checks, gotchas, downstream tables. Every fact traces to the elephant-xyz/skills docs or oracle-node code; assets the skills reference but that aren't yet published in oracle-node main are marked as such.
- `sources.schema.json` — JSON Schema (draft-07) so future counties stay uniform; validated with `npx --yes ajv-cli validate -s sources.schema.json -d sources.json`.
- `SOURCES.md` — human notes: the Accela wrong-parcel gotcha, the budget-handler incident, Deflate64, Cloudflare, US-egress gate.

URLs live-verified 2026-06-12 from US egress (`last_verified` stamped); bbb.org's 403 is its documented bot challenge.

## AC mapping (story: Oracle Agent Public Data Discovery and Refresh)

- "Identify public data sources" ×4 and "Store source metadata, including URLs, access patterns, and refresh methods" → this registry
- Consumed by the Oracle agent definition (companion PR: elephant-xyz/skills#1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
