### PR TITLE
fix(palm beach): map 6 unmapped DOR use codes (1301, 4805, 0630, 3942, 0031, 0051)

### DIFF
--- a/palm beach/scripts/data_extractor.js
+++ b/palm beach/scripts/data_extractor.js
@@ -516,6 +516,14 @@ const propertyTypeMapping = [
     "property_type": "Building"
   },
   {
+    "property_usecode": "1301 - SMALL DISCOUNT STORE < 25000 SF",
+    "ownership_estate_type": "FeeSimple",
+    "build_status": "Improved",
+    "structure_form": null,
+    "property_usage_type": "RetailStore",
+    "property_type": "Building"
+  },
+  {
     "property_usecode": "1304 - DEPT STORE CONDO",
     "ownership_estate_type": "Condominium",
     "build_status": "Improved",
@@ -628,6 +636,14 @@ const propertyTypeMapping = [
     "property_type": "Unit"
   },
   {
+    "property_usecode": "3942 - HOTEL TIMESHARE",
+    "ownership_estate_type": "Timeshare",
+    "build_status": "Improved",
+    "structure_form": null,
+    "property_usage_type": "Hotel",
+    "property_type": "Unit"
+  },
+  {
     "property_usecode": "2400 - INSURANCE",
     "ownership_estate_type": "FeeSimple",
     "build_status": "Improved",
@@ -657,6 +673,14 @@ const propertyTypeMapping = [
     "build_status": "Improved",
     "structure_form": null,
     "property_usage_type": "HomesForAged",
+    "property_type": "Building"
+  },
+  {
+    "property_usecode": "0630 - REHAB-DETOX",
+    "ownership_estate_type": "FeeSimple",
+    "build_status": "Improved",
+    "structure_form": null,
+    "property_usage_type": "SanitariumConvalescentHome",
     "property_type": "Building"
   },
   {
@@ -1356,6 +1380,14 @@ const propertyTypeMapping = [
     "property_type": "LandParcel"
   },
   {
+    "property_usecode": "0051 - VACANT SFR RES",
+    "ownership_estate_type": "FeeSimple",
+    "build_status": "VacantLand",
+    "structure_form": null,
+    "property_usage_type": "Residential",
+    "property_type": "LandParcel"
+  },
+  {
     "property_usecode": "0010 - VACANT TOWNHOUSE",
     "ownership_estate_type": "FeeSimple",
     "build_status": "VacantLand",
@@ -1365,6 +1397,14 @@ const propertyTypeMapping = [
   },
   {
     "property_usecode": "0030 - VACANT ZERO LOT LINE",
+    "ownership_estate_type": "FeeSimple",
+    "build_status": "VacantLand",
+    "structure_form": null,
+    "property_usage_type": "Residential",
+    "property_type": "LandParcel"
+  },
+  {
+    "property_usecode": "0031 - VACANT ZERO LOT LINE RES",
     "ownership_estate_type": "FeeSimple",
     "build_status": "VacantLand",
     "structure_form": null,
@@ -1386,6 +1426,14 @@ const propertyTypeMapping = [
     "structure_form": null,
     "property_usage_type": "Warehouse",
     "property_type": "Unit"
+  },
+  {
+    "property_usecode": "4805 - SELF STORAGE",
+    "ownership_estate_type": "FeeSimple",
+    "build_status": "Improved",
+    "structure_form": null,
+    "property_usage_type": "Warehouse",
+    "property_type": "Building"
   },
   {
     "property_usecode": "2900 - WHOLESALER",


### PR DESCRIPTION
## Problem

The Palm Beach transform (`palm beach/scripts/data_extractor.js`) throws
`ScriptsFailedError: Unknown enum value <code>, path property.property_type`
whenever the appraiser `UseCode` is not present in `propertyTypeMapping`
(`mapPropertyTypeFromUseCode` returns `null` → `extractProperty` throws). The
parcel then produces **no** `transformed_output.zip`, so it is silently dropped
from the dataset.

On the full `palm-beach-property-first-seed-all-20260630` appraisal run this
deterministically dropped **364 parcels** across 6 unmapped codes (authoritative
S3 count of row folders with `output.zip` but no `transformed_output.zip`):

| count | code | appraiser description |
|------:|------|-----------------------|
| 181 | 4805 | SELF STORAGE |
| 118 | 1301 | SMALL DISCOUNT STORE < 25000 SF |
|  45 | 0630 | REHAB-DETOX |
|  16 | 3942 | HOTEL TIMESHARE |
|   3 | 0031 | VACANT ZERO LOT LINE RES |
|   1 | 0051 | VACANT SFR RES |

## Fix

Add the 6 missing `propertyTypeMapping` entries. Each mirrors its use-code
family / nearest neighbor, and every target enum value is already used by
existing (schema-validated) entries in this file:

- **1301 → RetailStore / Building** — a small discount store is retail (like
  `1100 STORES`); `DepartmentStore` (1300) implies a large-format store, which
  contradicts "SMALL < 25000 SF".
- **4805 → Warehouse / Building** — self storage is an enclosed mini-warehouse
  (like `4800 WAREH/DIST TERM`); `OpenStorage` (4900) is a `LandParcel` for open
  land, wrong for a building.
- **0630 → SanitariumConvalescentHome / Building** — residential treatment /
  recovery facility (like `7800 SANI/REST HOME`).
- **3942 → Hotel / Unit, estate Timeshare** — hotel usage (like `3900 MOTEL` /
  `3904 HOTEL CONDO`) with timeshare interval ownership (estate like `0420
  TIMESHARE`).
- **0031 → Residential / LandParcel** — mirrors `0030 VACANT ZERO LOT LINE`.
- **0051 → Residential / LandParcel, fee simple** — vacant SFR land; non-condo
  counterpart of `0050 VACANT SFR CONDO`.

## Verification

- `node --check` passes; unit-checked that all 6 codes now resolve via
  `propertyTypeMapping` → `mapPropertyTypeFromUseCode`.
- The corresponding production transform zip was patched with the identical
  entries and the 364 affected parcels were redriven (transform-only); they now
  produce schema-valid `transformed_output.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)