### PR TITLE
fix(orange): stop doubling the house number in the situs address

### DIFF
--- a/orange/scripts/data_extractor.js
+++ b/orange/scripts/data_extractor.js
@@ -3387,8 +3387,12 @@ function main() {
       const propertyAddress = normSpace(
         generalProfile.propertyAddress || generalProfile.streetName || "",
       );
+      // OCPA's propertyAddress already includes the house number (e.g.
+      // "5034 LOYOLA LN"); only prepend streetNumber when it is missing (e.g.
+      // propertyAddress fell back to streetName), otherwise the number gets
+      // doubled ("5034 5034 LOYOLA LN").
       let locationLine = propertyAddress;
-      if (streetNumber) {
+      if (streetNumber && !propertyAddress.startsWith(`${streetNumber} `)) {
         locationLine = `${streetNumber} ${propertyAddress}`.trim();
       }
       if (!locationLine && generalProfile.streetName) {


### PR DESCRIPTION
## Problem
Orange's transform doubles the house number in the situs address. `address.json`'s `unnormalized_address` comes out as e.g. `"5034 5034 LOYOLA LN, Orlando, FL, 32821"`, `"10701 10701 LARISSA ST, ..."`. Verified systematic — **25/25** numbered addresses in a developed-area sample were doubled (rural/un-numbered parcels are unaffected).

## Root cause
`orange/scripts/data_extractor.js`: OCPA's `parcelGeneralProfile.propertyAddress` **already includes** the house number (`"5034 LOYOLA LN"`), but the code unconditionally prepended `streetNumber` again:
```js
let locationLine = propertyAddress;
if (streetNumber) { locationLine = `${streetNumber} ${propertyAddress}`.trim(); }
```

## Fix
Only prepend `streetNumber` when the address doesn't already start with it. This keeps the intended fallback (when `propertyAddress` is absent and `propertyAddress` falls back to `streetName`, which has no number, the number is still composed correctly).

## Verification
Logic check over the real doubled cases + the streetName-fallback + rural/no-number + streetNumber=0 → **5/5 pass**, no doubling.

## Impact / notes
- **Not a breaking change** — no data was lost; the clean value already existed in `unnormalized_address.json.full_address`. This corrects the `address` class copy.
- Already-scraped Orange rows can be corrected by a **re-transform only (no re-scrape)**; or consumers can read `full_address`.
- Scope: Orange only.