### PR TITLE
docs(overture): preserve Lee places pilot provenance

### DIFF
--- a/overture/NOTICE.template.txt
+++ b/overture/NOTICE.template.txt
@@ -1,0 +1,34 @@
+Overture Maps Foundation Places
+Release: {{OVERTURE_RELEASE}}
+Accessed: {{ACCESSED_DATE}}
+
+This dataset is derived from Overture Maps places data published at
+s3://overturemaps-us-west-2/release/{{OVERTURE_RELEASE}}/theme=places/type=place/.
+Overture theme licence: CDLA-Permissive-2.0 and Apache-2.0 per record, with no
+OpenStreetMap lineage in the places theme. These terms were read from Overture's
+published documentation on 2026-08-12 and have not been reviewed by counsel.
+
+Per-provider licences for datasets present in this extract ({{DATASETS}}):
+- meta: CDLA-Permissive-2.0
+- microsoft: CDLA-Permissive-2.0
+- foursquare: Apache-2.0
+- pinmeto: CDLA-Permissive-2.0
+- krick: CDLA-Permissive-2.0
+- rendersEO: CDLA-Permissive-2.0
+- dac: CDLA-Permissive-2.0
+- brightquery: CDLA-Permissive-2.0
+- alltheplaces: CDLA-Permissive-2.0
+- Overture: CDLA-Permissive-2.0 and Apache-2.0 (Overture theme lineage)
+- Overture-signals: CDLA-Permissive-2.0 and Apache-2.0 (Overture theme lineage)
+
+Copyright 2024 Foursquare Labs, Inc. All rights reserved.
+
+Changed by Elephant: {{ELEPHANT_CHANGED_DATE}}
+Elephant clipped the global places theme to a Census TIGER/Line county boundary,
+serialized taxonomy.hierarchy as a /-delimited string in the published parquet,
+and added an advisory is_hosted_service flag. This change statement describes
+Elephant's transformation, not Overture's.
+
+Joining CDLA-Permissive data to OpenStreetMap can make the resulting derivative
+database ODbL. Do not combine this artifact with an ODbL source without a
+licence review.

--- a/overture/README.md
+++ b/overture/README.md
@@ -1,0 +1,41 @@
+# Overture places
+
+This folder preserves the reviewable rules and provenance for county-scoped
+Overture Maps places publications. It contains metadata, configuration, and run
+evidence only.
+
+Extracted JSONL and source GeoParquet remain in object storage. Published
+county parquet remains in IPFS. No extracted place records, business contact
+records, credentials, or environment configuration belong in this repository.
+
+## Files
+
+- [`sources.yaml`](sources.yaml) records the approved Overture source datasets,
+  licences, attribution requirements, and publication hard stops.
+- [`config/hosted-service-categories.txt`](config/hosted-service-categories.txt)
+  is the release-scoped advisory taxonomy rule used to flag hosted services
+  without excluding them.
+- [`NOTICE.template.txt`](NOTICE.template.txt) is the publication notice
+  template.
+- [`runs/lee/2026-07-22.0/report.md`](runs/lee/2026-07-22.0/report.md) records
+  the Lee County pilot extraction, validation, load, and publication.
+- [`runs/lee/2026-07-22.0/NOTICE.txt`](runs/lee/2026-07-22.0/NOTICE.txt) is the
+  rendered notice shipped with that public artifact.
+
+## Hosted-service scope
+
+The committed taxonomy rule contains five Lee-verified, full
+`taxonomy.hierarchy` paths and flagged 956 rows in the Lee pilot. It is an
+evidence-based seed scope for Overture release `2026-07-22.0`; it is not a
+claimed or inferred 250-entry list. Any expansion requires observed full paths,
+review, and a release-scoped rule update.
+
+## Published Lee artifact
+
+The public Lee places parquet is:
+
+<https://ipfs.filebase.io/ipns/k51qzi5uqu5djfa3kbhcxedqlh7kiuyi22bd60he1nsa0wr2jrseo6vvxvwke5/lee/places-table.parquet>
+
+Its IPNS family includes the rendered `NOTICE.txt` and machine-readable
+`lee/index.json`. See the run report for the CID, gates, counts, and operator
+decisions.

--- a/overture/config/hosted-service-categories.txt
+++ b/overture/config/hosted-service-categories.txt
@@ -1,0 +1,45 @@
+# Hosted-service categories — services offered inside another business rather
+# than a business occupying a location of its own.
+#
+# Sets `business_locations.is_hosted_service = true` and records
+# `hosted_service_rule = 'hosted-service-categories@2026-07-22.0'`.
+# Advisory only: places are never excluded from ingestion on the strength of
+# this list, and consumers may ignore it.
+#
+# Format: one taxonomy path per line, `/`-delimited, L0 first.
+# Matching is on the full path so a rename at one level does not silently widen.
+#
+# Rebuilt from the Lee County extract of Overture 2026-07-22.0 against
+# `taxonomy.hierarchy` (40,191 clipped places, 1,194 distinct paths).
+#
+# Lee evidence for these five rules:
+# - financial_service/atm: 323
+# - rental_service/rental_kiosk: 83
+# - supplier_or_distributor/propane_supplier: 99
+# - financial_service/money_transfer_service: 351
+# - financial_service/trusts: 100
+# Total flags: 956.
+#
+# Judgement (2026-08-12): commit only the five named scoping concepts, resolved
+# onto observed full paths. The old flat `categories.primary` leaves were
+# plural (`atms`, `rental_kiosks`, `money_transfer_services`); the July 2026
+# taxonomy uses singular leaves (`atm`, `rental_kiosk`, `money_transfer_service`).
+# This evidence-based seed scope is not a claimed 250-entry list. The roughly
+# 250 hosted-looking values were counted against the deprecated vocabulary and
+# were never enumerated as hierarchy paths.
+#
+# Reviewed and rejected for this pass:
+# - shopping/kiosk — may occupy its own location
+# - .../vending_machine_supplier — B2B supplier, not a hosted machine
+# - .../wills_trusts_and_probate — a law firm, not a hosted trust desk
+# - medical `*_treatment_center` paths — false friends of the old leaf matcher
+# - window_treatment_store — not a hosted service
+#
+# Re-review whenever the taxonomy moves (quarterly: March, June, September,
+# December).
+
+services_and_business/financial_service/atm
+services_and_business/real_estate/real_estate_service/rental_service/rental_kiosk
+services_and_business/b2b_service/supplier_or_distributor/propane_supplier
+services_and_business/financial_service/money_transfer_service
+services_and_business/financial_service/trusts

--- a/overture/runs/lee/2026-07-22.0/NOTICE.txt
+++ b/overture/runs/lee/2026-07-22.0/NOTICE.txt
@@ -1,0 +1,33 @@
+Overture Maps Foundation Places
+Release: 2026-07-22.0
+Accessed: 2026-08-13
+
+This dataset is derived from Overture Maps places data published at
+s3://overturemaps-us-west-2/release/2026-07-22.0/theme=places/type=place/.
+Overture theme licence: CDLA-Permissive-2.0 and Apache-2.0 per record, with no
+OpenStreetMap lineage in the places theme. These terms were read from Overture's
+published documentation on 2026-08-12 and have not been reviewed by counsel.
+
+Per-provider licences for datasets present in this extract (AllThePlaces, BrightQuery, DAC, Foursquare, meta, Microsoft, Overture, Overture-signals, PinMeTo, RenderSEO):
+- AllThePlaces: CDLA-Permissive-2.0
+- BrightQuery: CDLA-Permissive-2.0
+- DAC: CDLA-Permissive-2.0
+- Foursquare: Apache-2.0
+- meta: CDLA-Permissive-2.0
+- Microsoft: CDLA-Permissive-2.0
+- Overture: CDLA-Permissive-2.0 and Apache-2.0 (Overture theme lineage)
+- Overture-signals: CDLA-Permissive-2.0 and Apache-2.0 (Overture theme lineage)
+- PinMeTo: CDLA-Permissive-2.0
+- RenderSEO: CDLA-Permissive-2.0
+
+Copyright 2024 Foursquare Labs, Inc. All rights reserved.
+
+Changed by Elephant: 2026-08-13
+Elephant clipped the global places theme to a Census TIGER/Line county boundary,
+serialized taxonomy.hierarchy as a /-delimited string in the published parquet,
+and added an advisory is_hosted_service flag. This change statement describes
+Elephant's transformation, not Overture's.
+
+Joining CDLA-Permissive data to OpenStreetMap can make the resulting derivative
+database ODbL. Do not combine this artifact with an ODbL source without a
+licence review.

--- a/overture/runs/lee/2026-07-22.0/report.md
+++ b/overture/runs/lee/2026-07-22.0/report.md
@@ -1,0 +1,119 @@
+# Lee County Overture places pilot
+
+This report records the metadata and operator decisions for the Lee County,
+Florida pilot. It does not contain extracted place records or business contact
+records.
+
+## Run identity
+
+- County: Lee, Florida
+- County FIPS: `12071`
+- Overture release: `2026-07-22.0`
+- STAC latest at extraction: `2026-07-22.0`
+- Boundary: Census TIGER/Line `tl_2024_us_county` (2024 vintage)
+- Extraction date: `2026-08-12`
+- Publication accessed/change date: `2026-08-13`
+- Extraction method: bounding-box pruning followed by `ST_Within` boundary clip
+
+## Reconciliation
+
+- Bounding-box candidates: 40,517. This is an intermediate optimization count,
+  not a publishable county count.
+- Boundary-clipped places: **40,191**.
+- Scoping baseline: 40,190.
+- Reconciliation: the verified TIGER 2024 clip produced one more place than the
+  scoping baseline. The baseline is not an `expected_count`.
+- Address-versus-geometry county discrepancies: 0.
+- Extraction duration: 363,985 ms, about 6.1 minutes.
+- Operating status: 25,049 open; 14,698 blank; 444 permanently closed.
+
+## Taxonomy and hosted-service rules
+
+- Distinct `taxonomy.primary` values: 1,195.
+- Distinct full `taxonomy.hierarchy` paths: 1,194.
+- Hosted-service rules: five release-scoped, full hierarchy paths.
+- Hosted-service flags: **956** total: ATM 323, rental kiosk 83, propane
+  supplier 99, money transfer service 351, and trusts 100.
+
+The five rules are preserved in
+[`../../../config/hosted-service-categories.txt`](../../../config/hosted-service-categories.txt).
+They are an evidence-based seed scope, not a claimed 250-entry list. Places
+were flagged advisory-only and were not excluded.
+
+## Source and licence gate
+
+Observed `sources[].dataset` values were:
+
+- `AllThePlaces`
+- `BrightQuery`
+- `DAC`
+- `Foursquare`
+- `meta`
+- `Microsoft`
+- `Overture`
+- `Overture-signals`
+- `PinMeTo`
+- `RenderSEO`
+
+The case-insensitive source gate passed for all 40,191 places:
+
+- unknown datasets: none
+- OSM present: false
+- `Overture` and `Overture-signals`: allowed by human decision on `2026-08-12`
+  as Overture's own lineage
+- OSM or any future unknown dataset: hard stop; do not publish
+
+The approved source and licence record is
+[`../../../sources.yaml`](../../../sources.yaml).
+
+## Neon load and coverage
+
+- `business_locations`: **40,191**, matching the clipped extract.
+- `business_location_categories`: 38,137.
+- `business_location_sources`: 297,856; source gate passed.
+- `overture_place_extractions`: 1 for Lee and this release.
+- Geometry present: 40,191.
+- Parcel links: 0; intentionally deferred.
+- Company links: 0; intentionally not inferred at ingest.
+- `oracle_dataset_coverage.ingested_count`: 40,191.
+- `oracle_dataset_coverage.expected_count`: **NULL**. There is no authoritative
+  denominator for all Lee County business locations, so completeness must not
+  be reported as an artificial 100%.
+
+## DBPR salon quality check
+
+Florida DBPR listed 1,420 licensed salon establishments in Lee. Overture had
+1,435 places whose primary taxonomy was `beauty_salon`, `hair_salon`,
+`nail_salon`, or `barber` (514 + 453 + 268 + 200). The earlier scoping figure
+was 1,436 before the final clip reconciliation.
+
+The close agreement is evidence of sector coverage only. DBPR covers one
+licensed sector and is not an `expected_count` for all places.
+
+## Publication
+
+- Human PII decision (`2026-08-12`): approved to publish public business
+  emails and phones as-is.
+- Filebase bucket: `elephant-oracle-open-data-lee-places`.
+- IPNS label: `oracle-open-data-lee-places`.
+- IPNS name:
+  `k51qzi5uqu5djfa3kbhcxedqlh7kiuyi22bd60he1nsa0wr2jrseo6vvxvwke5`.
+- Directory CID:
+  `bafybeicfvfm5reer2ugipirxufpu6u3tmseoezsdfyhseysoo6p5r2mj4a`.
+- Public parquet:
+  <https://ipfs.filebase.io/ipns/k51qzi5uqu5djfa3kbhcxedqlh7kiuyi22bd60he1nsa0wr2jrseo6vvxvwke5/lee/places-table.parquet>
+- Gateway verification: `2026-08-13T03:59:11Z`.
+- Rendered publication notice:
+  [`NOTICE.txt`](NOTICE.txt).
+
+Pre-publication gates passed:
+
+- parquet rows 40,191 == current Lee Neon rows for this release
+- duplicate GERS IDs: 0
+- null geometries: 0
+- OSM present: false
+- unknown source datasets: none
+- `taxonomy.hierarchy` serialized as `/`-delimited scalar paths
+
+The IPNS family contains the public parquet, `lee/index.json`, and the rendered
+root `NOTICE.txt`. Extracted JSONL and source parquet are not stored in git.

--- a/overture/sources.yaml
+++ b/overture/sources.yaml
@@ -1,0 +1,76 @@
+schema_version: 1
+
+source:
+  key: overture-places
+  name: Overture Maps places
+  authority: Overture Maps Foundation
+  stac_catalog: "https://stac.overturemaps.org/catalog.json"
+  public_s3_prefix: "s3://overturemaps-us-west-2/release/<release>/theme=places/type=place/"
+  azure_mirror: "https://overturemapswestus2.blob.core.windows.net/release/"
+  access:
+    mode: public-s3-geoparquet
+    authentication: none
+    region: us-west-2
+  cadence: monthly
+  identity: GERS UUID
+  county_scope: Census TIGER/Line boundary clip after bounding-box pruning
+  category_fields:
+    hierarchy: taxonomy.hierarchy
+    primary: taxonomy.primary
+    alternate: taxonomy.alternate
+    basic: basic_category
+    deprecated: categories.primary
+
+licensing:
+  theme_license: CDLA-Permissive-2.0 and Apache-2.0 per record
+  publication: open-with-attribution
+  verified_at: "2026-08-12"
+  counsel_reviewed: false
+  approved_datasets:
+    - dataset: meta
+      license: CDLA-Permissive-2.0
+    - dataset: microsoft
+      license: CDLA-Permissive-2.0
+    - dataset: foursquare
+      license: Apache-2.0
+      attribution: "Copyright 2024 Foursquare Labs, Inc. All rights reserved."
+    - dataset: pinmeto
+      license: CDLA-Permissive-2.0
+    - dataset: krick
+      license: CDLA-Permissive-2.0
+    - dataset: rendersEO
+      license: CDLA-Permissive-2.0
+    - dataset: dac
+      license: CDLA-Permissive-2.0
+    - dataset: brightquery
+      license: CDLA-Permissive-2.0
+    - dataset: alltheplaces
+      license: CDLA-Permissive-2.0
+    - dataset: Overture
+      license: CDLA-Permissive-2.0 and Apache-2.0
+      approval: human-decision-2026-08-12-overture-lineage
+    - dataset: Overture-signals
+      license: CDLA-Permissive-2.0 and Apache-2.0
+      approval: human-decision-2026-08-12-overture-lineage
+  gate:
+    comparison: case-insensitive
+    osm: hard-stop
+    unknown_dataset: hard-stop
+    decision: Do not publish if OSM or any dataset outside the approved list appears.
+  human_decision:
+    date: "2026-08-12"
+    statement: Overture and Overture-signals are Overture lineage, not OSM or unknown third-party sources, and are approved.
+  attribution_requirements:
+    - Preserve the Overture citation and accessed date.
+    - Preserve licences for every provider dataset present.
+    - Preserve the Foursquare copyright line when Foursquare is present.
+    - Record Elephant's transformation and change date.
+    - Ship NOTICE.txt with the published artifact.
+  caveat: Joining CDLA-Permissive data to OpenStreetMap can make the resulting derivative database ODbL and requires licence review.
+
+publication_decisions:
+  lee:
+    decided_at: "2026-08-12"
+    decision: approved
+    pii: Publish public business emails and phones as-is.
+    gate: Licence assertion passes, row count reconciles, and duplicate GERS IDs and null geometries are zero.


### PR DESCRIPTION
## Summary
- add an `overture/` metadata hierarchy for the approved source datasets, licence gate, attribution requirements, and Lee publication decisions
- preserve the five full-path hosted-service taxonomy rules (956 Lee flags), the `2026-07-22.0` run report, and the exact rendered publication notice
- keep extracted place records out of git; no JSONL, parquet, contact records, credentials, or environment configuration are included

Public Lee places parquet: https://ipfs.filebase.io/ipns/k51qzi5uqu5djfa3kbhcxedqlh7kiuyi22bd60he1nsa0wr2jrseo6vvxvwke5/lee/places-table.parquet

## Test plan
- [x] `git diff --check`
- [x] parse `overture/sources.yaml`
- [x] verify exactly five unique full taxonomy paths
- [x] compare the committed Lee `NOTICE.txt` byte-for-byte with the public IPNS artifact
- [x] verify no `.jsonl` or `.parquet` files are included

The repository has no root automated test, lint, or format harness applicable to these metadata-only files.

Made with [Cursor](https://cursor.com)